### PR TITLE
Changed the typescript dependency from a dev dependency to a library dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,10 @@
   ],
   "dependencies": {
     "lodash": "~2.4.1",
-    "iswin": "0.0.2"
+    "iswin": "0.0.2",
+    "typescript": "~1.0"
   },
   "devDependencies": {
-    "typescript": "~1.0",
     "grunt": "~0.4",
     "grunt-contrib-jshint": "~0.10",
     "grunt-npm": "~0.0.2",


### PR DESCRIPTION
The reason for this is in the index.js line 48 breaks when it's being used by another package.
 This gets called when no compiler option is set and so  does a requires("typescript").
 In this case typescript wouldn't have been installed as a dependency and so it fails.

Could you please update karma-typescript-preprocessor after?